### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Library that implements the floating action button to sheet [transition](https:/
 ### Gradle
 Add the dependency (available from mavenCentral and jcenter) to your `build.gradle`:  
 ```groovy
-compile 'com.gordonwong:material-sheet-fab:1.2.1'
+implementation 'com.gordonwong:material-sheet-fab:1.2.1'
 ```
 
 ### Proguard


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.