### PR TITLE
Allow disabling sheet auto-placement

### DIFF
--- a/material-sheet-fab/src/main/java/com/gordonwong/materialsheetfab/MaterialSheetFab.java
+++ b/material-sheet-fab/src/main/java/com/gordonwong/materialsheetfab/MaterialSheetFab.java
@@ -61,6 +61,7 @@ public class MaterialSheetFab<FAB extends View & AnimatedFab> {
 	private boolean isShowing;
 	private boolean isHiding;
 	private boolean hideSheetAfterSheetIsShown;
+	private boolean autoPositionSheet = true;
 
 	// Listeners
 	private MaterialSheetFabEventListener eventListener;
@@ -130,6 +131,13 @@ public class MaterialSheetFab<FAB extends View & AnimatedFab> {
 					}
 				});
 	}
+
+    /**
+     * Enable the consumer to disable sheet auto positioning; fab will travel to wherever the sheet is
+     */
+	public void setAutoPositionSheet(Boolean value) {
+	    autoPositionSheet = value;
+    }
 
 	/**
 	 * Shows the FAB.
@@ -260,8 +268,10 @@ public class MaterialSheetFab<FAB extends View & AnimatedFab> {
 		// sheet
 		updateFabAnchor();
 
-		// Align sheet's position with FAB
-		sheetAnimation.alignSheetWithFab(fab);
+		// Align sheet's position with FAB, if desired
+        if (autoPositionSheet) {
+            sheetAnimation.alignSheetWithFab(fab);
+        }
 
 		// Morph FAB into sheet
 		fabAnimation.morphIntoSheet(sheetAnimation.getSheetRevealCenterX(),


### PR DESCRIPTION
My app has a center-aligned sheet that I needed the fab to animate to, and in the existing implementation the sheet gets auto-aligned to the origin of the fab. I added a property and a setter so that it could be turned off. Kudos to you that after turning it off the fab just goes where it should! So this is how I'm consuming:

```kotlin
val mainFab = MaterialSheetFab(add_site_fab,
                card,
                overlay,
                getColor(android.R.color.white),
                getColor(android.R.color.holo_red_light))
mainFab.setAutoPositionSheet(false)
```

Again, everything just works in this case! Let me know if you want this property to be set in a different manner or in a different place.